### PR TITLE
Clearer params

### DIFF
--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
@@ -17,6 +17,7 @@
 package com.hadisatrio.libs.android.viewmodelprovider;
 
 import com.google.auto.service.AutoService;
+import com.hadisatrio.libs.android.viewmodelprovider.internal.Pair;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
@@ -203,7 +204,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
 
         final String packageName = getPackageName(typeElement);
         final String genClassName = typeElement.getSimpleName() + FACTORY_CLASS_SUFFIX;
-        final List<TypeMirror> ctorParams = getConstructorParamTypes(typeElement);
+        final List<Pair<TypeMirror, String>> ctorParams = getConstructorParameters(typeElement);
 
         // Define the fields based on previously queried constructor params.
         final List<FieldSpec> fieldSpecs = new ArrayList<>();
@@ -212,7 +213,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
         for (int i = 0; i < ctorParams.size(); i++) {
             fieldSpecs.add(
                     FieldSpec.builder(
-                            TypeName.get(ctorParams.get(i)),
+                            TypeName.get(ctorParams.get(i).getLeft()),
                             VARIABLE_PREFIX + i,
                             Modifier.PRIVATE,
                             Modifier.FINAL
@@ -220,7 +221,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
             );
 
             if (fieldTypesCsv.length() > 0) fieldTypesCsv.append(',');
-            fieldTypesCsv.append(TypeName.get(ctorParams.get(i))).append(".class");
+            fieldTypesCsv.append(TypeName.get(ctorParams.get(i).getLeft())).append(".class");
 
             if (fieldNamesCsv.length() > 0) fieldNamesCsv.append(',');
             fieldNamesCsv.append(VARIABLE_PREFIX).append(i);
@@ -230,7 +231,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
         final MethodSpec.Builder ctorSpecBuilder = MethodSpec.constructorBuilder();
         for (int i = 0; i < ctorParams.size(); i++) {
             ctorSpecBuilder.addParameter(
-                    TypeName.get(ctorParams.get(i)),
+                    TypeName.get(ctorParams.get(i).getLeft()),
                     PARAMS_PREFIX + i
             );
 
@@ -285,13 +286,13 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
         return pkg.getQualifiedName().toString();
     }
 
-    private List<TypeMirror> getConstructorParamTypes(TypeElement typeElement) {
-        final List<TypeMirror> subjectCtorParams = new ArrayList<>();
+    private List<Pair<TypeMirror, String>> getConstructorParameters(TypeElement typeElement) {
+        final List<Pair<TypeMirror, String>> subjectCtorParams = new ArrayList<>();
         for (Element element : typeElement.getEnclosedElements()) {
             if (element.getKind() == ElementKind.CONSTRUCTOR) {
                 final ExecutableElement ctor = ((ExecutableElement) element);
                 for (VariableElement ctorParameter : ctor.getParameters()) {
-                    subjectCtorParams.add(ctorParameter.asType());
+                    subjectCtorParams.add(new Pair<>(ctorParameter.asType(), ctorParameter.getSimpleName().toString()));
                 }
             }
         }
@@ -303,7 +304,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
 
         final String packageName = getPackageName(typeElement);
         final String genClassName = typeElement.getSimpleName() + PROVIDER_CLASS_SUFFIX;
-        final List<TypeMirror> subjectCtorParams = getConstructorParamTypes(typeElement);
+        final List<Pair<TypeMirror, String>> subjectCtorParams = getConstructorParameters(typeElement);
         final Class viewModelProviderClass = Class.forName(VIEW_MODEL_PROVIDERS_CLASS_NAME);
 
         final StringBuilder ctorParamNamesCsv = new StringBuilder();
@@ -318,7 +319,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_ACTIVITY_CLASS_NAME), "activity");
         for (int i = 0; i < subjectCtorParams.size(); i++) {
-            activityGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i)), (PARAMS_PREFIX + (i + 1)));
+            activityGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), (PARAMS_PREFIX + (i + 1)));
         }
         activityGetBuilder.addStatement("return $T.of(activity, new $TFactory($L)).get($T.class)", viewModelProviderClass, typeElement, ctorParamNamesCsv, typeElement);
         final MethodSpec activityGet = activityGetBuilder.build();
@@ -329,7 +330,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_CLASS_NAME), "fragment");
         for (int i = 0; i < subjectCtorParams.size(); i++) {
-            fragmentGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i)), (PARAMS_PREFIX + (i + 1)));
+            fragmentGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), (PARAMS_PREFIX + (i + 1)));
         }
         fragmentGetBuilder.addStatement("return $T.of(fragment, new $TFactory($L)).get($T.class)", viewModelProviderClass, typeElement, ctorParamNamesCsv, typeElement);
         final MethodSpec fragmentGet = fragmentGetBuilder.build();

--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
@@ -211,9 +211,11 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
         final StringBuilder fieldTypesCsv = new StringBuilder();
         final StringBuilder fieldNamesCsv = new StringBuilder();
         for (int i = 0; i < ctorParams.size(); i++) {
+            final TypeName paramType = TypeName.get(ctorParams.get(i).getLeft());
+
             fieldSpecs.add(
                     FieldSpec.builder(
-                            TypeName.get(ctorParams.get(i).getLeft()),
+                            paramType,
                             VARIABLE_PREFIX + i,
                             Modifier.PRIVATE,
                             Modifier.FINAL
@@ -221,7 +223,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
             );
 
             if (fieldTypesCsv.length() > 0) fieldTypesCsv.append(',');
-            fieldTypesCsv.append(TypeName.get(ctorParams.get(i).getLeft())).append(".class");
+            fieldTypesCsv.append(paramType).append(".class");
 
             if (fieldNamesCsv.length() > 0) fieldNamesCsv.append(',');
             fieldNamesCsv.append(VARIABLE_PREFIX).append(i);
@@ -303,6 +305,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
             throws IOException, ClassNotFoundException, NoPackageNameException {
 
         final String packageName = getPackageName(typeElement);
+        final TypeName typeName = TypeName.get(typeElement.asType());
         final String genClassName = typeElement.getSimpleName() + PROVIDER_CLASS_SUFFIX;
         final List<Pair<TypeMirror, String>> subjectCtorParams = getConstructorParameters(typeElement);
         final Class viewModelProviderClass = Class.forName(VIEW_MODEL_PROVIDERS_CLASS_NAME);
@@ -315,7 +318,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
 
         // Generate `get()` method to be called from activities.
         final MethodSpec.Builder activityGetBuilder = MethodSpec.methodBuilder("get")
-                .returns(TypeName.get(typeElement.asType()))
+                .returns(typeName)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_ACTIVITY_CLASS_NAME), "activity");
         for (int i = 0; i < subjectCtorParams.size(); i++) {
@@ -326,7 +329,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
 
         // Generate `get()` method to be called from fragments.
         final MethodSpec.Builder fragmentGetBuilder = MethodSpec.methodBuilder("get")
-                .returns(TypeName.get(typeElement.asType()))
+                .returns(typeName)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_CLASS_NAME), "fragment");
         for (int i = 0; i < subjectCtorParams.size(); i++) {

--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
@@ -310,7 +310,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
         final StringBuilder ctorParamNamesCsv = new StringBuilder();
         for (int i = 0; i < subjectCtorParams.size(); i++) {
             if (ctorParamNamesCsv.length() > 0) ctorParamNamesCsv.append(',');
-            ctorParamNamesCsv.append(PARAMS_PREFIX).append(i + 1);
+            ctorParamNamesCsv.append(subjectCtorParams.get(i).getRight());
         }
 
         // Generate `get()` method to be called from activities.
@@ -319,7 +319,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_ACTIVITY_CLASS_NAME), "activity");
         for (int i = 0; i < subjectCtorParams.size(); i++) {
-            activityGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), (PARAMS_PREFIX + (i + 1)));
+            activityGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), subjectCtorParams.get(i).getRight());
         }
         activityGetBuilder.addStatement("return $T.of(activity, new $TFactory($L)).get($T.class)", viewModelProviderClass, typeElement, ctorParamNamesCsv, typeElement);
         final MethodSpec activityGet = activityGetBuilder.build();
@@ -330,7 +330,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ClassName.bestGuess(FRAGMENT_CLASS_NAME), "fragment");
         for (int i = 0; i < subjectCtorParams.size(); i++) {
-            fragmentGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), (PARAMS_PREFIX + (i + 1)));
+            fragmentGetBuilder.addParameter(TypeName.get(subjectCtorParams.get(i).getLeft()), subjectCtorParams.get(i).getRight());
         }
         fragmentGetBuilder.addStatement("return $T.of(fragment, new $TFactory($L)).get($T.class)", viewModelProviderClass, typeElement, ctorParamNamesCsv, typeElement);
         final MethodSpec fragmentGet = fragmentGetBuilder.build();

--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/internal/Pair.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/internal/Pair.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright (C) 2017 Hadi Satrio
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.hadisatrio.libs.android.viewmodelprovider.internal;
+
+public final class Pair<L, R> {
+
+    private final L left;
+    private final R right;
+
+    public Pair(L left, R right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public L getLeft() {
+        return left;
+    }
+
+    public R getRight() {
+        return right;
+    }
+}


### PR DESCRIPTION
Improve clarity of generated provider parameters by keeping names defined in original constructor of the annotated view model.