### PR TITLE
Mitigate multi-constructor scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,36 @@ Getting Alfred to automagically simplify your `ViewModel` instantiation is dead 
 ```
 
 
+### Current limitation
+
+As of its current state, `Alfred` is limited to process only the first constructor declared on each `ViewModel`.
+You could override this behaviour by explicitly annotating the constructor you want it to process instead with `@Main`:
+
+```
+   @GeneratedProvider
+   public final class SomeViewModel extends ViewModel {
+   
+      private final int someInt;
+      private final String someString;
+      private final SomeClass someClass;
+      private final SomeEnum someEnum;
+      
+      public SomeViewModel(int anInt, String aString, SomeClass yourClass) {
+         this(anInt, aString, yourClass, SomeEnum.NONE);
+      }
+      
+      @Main /* Tells Alfred to process this instead of the first one above. */
+      public SomeViewModel(int anInt, String aString, SomeClass yourClass, SomeEnum someEnum) {
+         ...
+      }
+      
+      ...
+   }
+```
+
+Please note that there could only be one `@Main`-annotated constructor declared in your `ViewModel`.
+
+
 ### Including `Alfred` to your project
 
 Include `Alfred` to your Gradle project by adding it as a dependency in your `build.gradle`:

--- a/annotations/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/Main.java
+++ b/annotations/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/Main.java
@@ -1,0 +1,24 @@
+/*
+ *    Copyright (C) 2017 Hadi Satrio
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.hadisatrio.libs.android.viewmodelprovider;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+public @interface Main {
+}

--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/DuplicateMainConstructorException.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/DuplicateMainConstructorException.java
@@ -1,0 +1,20 @@
+/*
+ *    Copyright (C) 2017 Hadi Satrio
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.hadisatrio.libs.android.viewmodelprovider;
+
+class DuplicateMainConstructorException extends Exception {
+}

--- a/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/AnotherDopeViewModel.java
+++ b/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/AnotherDopeViewModel.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (C) 2017 Hadi Satrio
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.hadisatrio.apps.android.alfreddemo;
+
+import android.arch.lifecycle.ViewModel;
+import android.content.Context;
+
+import com.hadisatrio.libs.android.viewmodelprovider.GeneratedProvider;
+import com.hadisatrio.libs.android.viewmodelprovider.Main;
+
+@GeneratedProvider
+public final class AnotherDopeViewModel extends ViewModel {
+
+    private final Context context;
+    private final Long fucksGiven;
+    private final String whatNot;
+
+    public AnotherDopeViewModel(Context context, Long fucksGiven) {
+        this(context, fucksGiven, "");
+    }
+
+    @Main
+    public AnotherDopeViewModel(Context context, Long fucksGiven, String whatNot) {
+        this.context = context;
+        this.fucksGiven = fucksGiven;
+        this.whatNot = whatNot;
+    }
+}

--- a/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/SeeAlfredInAction.java
+++ b/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/SeeAlfredInAction.java
@@ -23,6 +23,7 @@ import android.support.v7.app.AppCompatActivity;
 public final class SeeAlfredInAction extends AppCompatActivity {
 
     private DopeViewModel dopeViewModel;
+    private AnotherDopeViewModel anotherDopeViewModel;
     private LameViewModel lameViewModel;
     private EvenLamerViewModel evenLamerViewModel;
 
@@ -32,8 +33,9 @@ public final class SeeAlfredInAction extends AppCompatActivity {
 
         setContentView(R.layout.activity_see_alfred_in_action);
 
-        // This is dope...
+        // These are dope...
         dopeViewModel = DopeViewModelProvider.get(this, this, 0L);
+        anotherDopeViewModel = AnotherDopeViewModelProvider.get(this, this, 0L, "");
 
         // ...this is lame..
         lameViewModel = ViewModelProviders.of(this, new CustomViewModelFactory(this, 0L)).get(LameViewModel.class);


### PR DESCRIPTION
Limit `Alfred` to only process either one of these candidates while generating factories and providers:

1. The first constructor it sees, or
2. `@Main`-annotated constructor

This is to avoid issues like #5 happening again in the future.