### PR TITLE
Make the generated ViewModelFactories more performant

### DIFF
--- a/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
+++ b/compiler/src/main/java/com/hadisatrio/libs/android/viewmodelprovider/GeneratedProviderProcessor.java
@@ -222,7 +222,6 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
 
         // Define the fields based on previously queried constructor params.
         final List<FieldSpec> fieldSpecs = new ArrayList<>();
-        final StringBuilder fieldTypesCsv = new StringBuilder();
         final StringBuilder fieldNamesCsv = new StringBuilder();
         for (int i = 0; i < ctorParams.size(); i++) {
             TypeName paramType = TypeName.get(ctorParams.get(i).getLeft());
@@ -241,9 +240,6 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                             Modifier.FINAL
                     ).build()
             );
-
-            if (fieldTypesCsv.length() > 0) fieldTypesCsv.append(',');
-            fieldTypesCsv.append(paramType).append(".class");
 
             if (fieldNamesCsv.length() > 0) fieldNamesCsv.append(',');
             fieldNamesCsv.append(VARIABLE_PREFIX).append(i);
@@ -275,15 +271,7 @@ public final class GeneratedProviderProcessor extends AbstractProcessor {
                 .addTypeVariable(typeVariableName)
                 .returns(typeVariableName)
                 .addParameter(ParameterizedTypeName.get(ClassName.get(Class.class), typeVariableName), "modelClass")
-                .beginControlFlow("if ($T.class.isAssignableFrom($L))", typeElement, "modelClass")
-                .beginControlFlow("try")
-                .addStatement("return $L.getConstructor($L).newInstance($L)", "modelClass", fieldTypesCsv, fieldNamesCsv)
-                .nextControlFlow("catch ($T | $T | $T | $T e)", NoSuchMethodException.class, IllegalAccessException.class, InstantiationException.class, InvocationTargetException.class)
-                .addStatement("throw new $T(\"Couldn't create an instance of $T\", e)", RuntimeException.class, typeElement)
-                .endControlFlow()
-                .nextControlFlow("else")
-                .addStatement("throw new $T(\"Couldn't create an instance of $T\")", RuntimeException.class, typeElement)
-                .endControlFlow()
+                .addStatement("return (T) new $T($L)", typeElement, fieldNamesCsv)
                 .build();
 
         // Define the class using the previously defined specs.

--- a/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/CustomViewModelFactory.java
+++ b/demo/src/main/java/com/hadisatrio/apps/android/alfreddemo/CustomViewModelFactory.java
@@ -34,7 +34,7 @@ public final class CustomViewModelFactory implements ViewModelProvider.Factory {
 
     @Override
     public <T extends ViewModel> T create(Class<T> modelClass) {
-        if (DopeViewModel.class.isAssignableFrom(modelClass)) {
+        if (LameViewModel.class.isAssignableFrom(modelClass)) {
             try {
                 return modelClass.getConstructor(android.content.Context.class, java.lang.Long.class)
                         .newInstance(context, fucksGiven);

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -17,7 +17,7 @@ ext {
     targetCompatibilityVersion = "1.7" // JavaVersion.VERSION_1_7
 
     // Plugins / Build-Level Versions
-    androidGradleVersion = "3.0.0-beta2"
+    androidGradleVersion = "3.0.0-beta5"
 
     // 1st Party Android Library Versions
     supportLibraryVersion = "26.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,4 +17,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Since we know the exact return type, we can avoid using generics to instantiate it.

Before:

```java
@Override
public <T extends ViewModel> T create(Class<T> modelClass) {
  if (DopeViewModel.class.isAssignableFrom(modelClass)) {
    try {
      return modelClass.getConstructor(android.content.Context.class,java.lang.Long.class).newInstance(var0,var1);
    } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
      throw new RuntimeException("Couldn't create an instance of DopeViewModel", e);
    }
  } else {
    throw new RuntimeException("Couldn't create an instance of DopeViewModel");
  }
}
```

After:

```java
@Override
public <T extends ViewModel> T create(Class<T> modelClass) {
  return (T) new DopeViewModel(var0,var1);
}
```

I also updated the Android Gradle plugin and Gradle itself.